### PR TITLE
criando cache no servidor

### DIFF
--- a/pages/api/tempo.js
+++ b/pages/api/tempo.js
@@ -11,6 +11,11 @@ async function tempo(request, response) {
   //const inscritos = subscriberResponseJson.total_subscribers;
   const inscritos = subscriberResponseJson.message;
   
+  //criando cache para não sobrecarregar de requisições o banco de dados ou a api
+  //header do tipo controle do cache
+  //valor = endpoint com cache no servidor da vercel de 10 segundos
+  //stale-while-realidate - responder instantaneamente enquanto a vercel tenta autualizar a cache
+  response.setHeader('Cache-Control', 's-maxage-10', 'stale-while-realidate');
   response.json({
     date: dynamicDate.toGMTString(),
     inscritos: inscritos


### PR DESCRIPTION
criando cache no endpoint, para que não sobrecarrega o servidor com requisições, livrando a API ou banco de dados de travamento